### PR TITLE
ensure tcp.Send will read long messages fully

### DIFF
--- a/raidman.go
+++ b/raidman.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 
 	pb "code.google.com/p/goprotobuf/proto"
-	"./proto"
+	"github.com/swdunlop/raidman/proto"
 )
 
 type network interface {


### PR DESCRIPTION
TCP connections may not complete a read request if it exceeds the available data, resulting in short reads that confuse pb.Unmarshal with a long tail of null bytes:

```
!! proto: illegal tag 0
```

This pull request reads in a loop until the response is complete or an error is presented.  You might also want to place a license in you repo -- I release the enclosed commits to the public domain. Thanks for the package, @amir. :)
