### PR TITLE
protobufs moved off of code.google.com

### DIFF
--- a/proto/proto.pb.go
+++ b/proto/proto.pb.go
@@ -4,7 +4,7 @@
 
 package proto
 
-import proto1 "code.google.com/p/goprotobuf/proto"
+import proto1 "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/raidman.go
+++ b/raidman.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"sync"
 
-	pb "code.google.com/p/goprotobuf/proto"
+	pb "github.com/golang/protobuf/proto"
 	"github.com/amir/raidman/proto"
 )
 


### PR DESCRIPTION
So go get is broken for new installs.