### PR TITLE
Add support for sending multiple events

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,36 @@ func main() {
                 Ttl:     10,
         }
 
+        // send one event
         err = c.Send(event)
+        if err != nil {
+                panic(err)
+        }
+        
+        // send multiple events at once
+        err = c.SendMulti([]*raidman.Event{
+                &raidman.Event{
+                        State:   "success",
+                        Host:    "raidman",
+                        Service: "raidman-sample",
+                        Metric:  100,
+                        Ttl:     10,
+                },
+                &raidman.Event{
+                        State:   "failure",
+                        Host:    "raidman",
+                        Service: "raidman-sample",
+                        Metric:  100,
+                        Ttl:     10,
+                },
+                &raidman.Event{
+                        State:   "success",
+                        Host:    "raidman",
+                        Service: "raidman-sample",
+                        Metric:  100,
+                        Ttl:     10,
+                },
+        })
         if err != nil {
                 panic(err)
         }

--- a/raidman_test.go
+++ b/raidman_test.go
@@ -48,6 +48,48 @@ func TestTCP(t *testing.T) {
 	c.Close()
 }
 
+func TestMultiTCP(t *testing.T) {
+	c, err := Dial("tcp", "localhost:5555")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	
+	err = c.SendMulti([]*Event{
+		&Event{
+			State:      "success",
+			Host:       "raidman",
+			Service:    "tcp-multi-1",
+			Metric:     42,
+			Ttl:        1,
+			Tags:       []string{"tcp", "test", "raidman", "multi"},
+			Attributes: map[string]string{"type": "test"},
+		},
+		&Event{
+			State:      "success",
+			Host:       "raidman",
+			Service:    "tcp-multi-2",
+			Metric:     42,
+			Ttl:        1,
+			Tags:       []string{"tcp", "test", "raidman", "multi"},
+			Attributes: map[string]string{"type": "test"},
+		},
+	})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	events, err := c.Query("tagged \"test\" and tagged \"multi\"")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if len(events) != 2 {
+		t.Error("Submitted event not found")
+	}
+
+	c.Close()
+}
+
 func TestUDP(t *testing.T) {
 	c, err := Dial("udp", "localhost:5555")
 	if err != nil {


### PR DESCRIPTION
Since Riemann sends an acknowledgement for each Message received, and each Message can contain multiple Events, it's much more efficient to send multiple Events at once, when possible.