### PR TITLE
Handle metrics of type int64

### DIFF
--- a/raidman.go
+++ b/raidman.go
@@ -184,6 +184,9 @@ func eventToPbEvent(event *Event) (*proto.Event, error) {
 				case reflect.Int:
 					tmp := reflect.ValueOf(pb.Int64(int64(value.Int())))
 					t.FieldByName("MetricSint64").Set(tmp)
+				case reflect.Int64:
+					tmp := reflect.ValueOf(pb.Int64(int64(value.Int())))
+					t.FieldByName("MetricSint64").Set(tmp)
 				case reflect.Float32:
 					tmp := reflect.ValueOf(pb.Float32(float32(value.Float())))
 					t.FieldByName("MetricF").Set(tmp)

--- a/raidman_test.go
+++ b/raidman_test.go
@@ -90,6 +90,30 @@ func TestMultiTCP(t *testing.T) {
 	c.Close()
 }
 
+func TestMetricIsInt64(t *testing.T) {
+	c, err := Dial("tcp", "localhost:5555")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var int64metric int64 = 9223372036854775807
+
+	var event = &Event{
+		State:      "success",
+		Host:       "raidman",
+		Service:    "tcp",
+		Metric:     int64metric,
+		Ttl:        1,
+		Tags:       []string{"tcp", "test", "raidman"},
+		Attributes: map[string]string{"type": "test"},
+	}
+
+	err = c.Send(event)
+	if err != nil {
+		t.Error(err.Error())
+	}
+}
+
 func TestUDP(t *testing.T) {
 	c, err := Dial("udp", "localhost:5555")
 	if err != nil {


### PR DESCRIPTION
I'm attempting to use this with influxdb/telegraf which uses int64 for metric values.