### PR TITLE
Fix go vet issues

### DIFF
--- a/raidman.go
+++ b/raidman.go
@@ -91,11 +91,10 @@ func newDialer() (proxy.Dialer, error) {
 	if len(proxyUrl) > 0 {
 		u, err := url.Parse(proxyUrl)
 		if err != nil {
-			fmt.Errorf("failed to obtain proxy dialer: %v\n", err)
+			return nil, fmt.Errorf("failed to obtain proxy dialer: %v\n", err)
 		}
 		if dialer, err = proxy.FromURL(u, dialer); err != nil {
-			fmt.Errorf("failed to parse  " + proxyUrl + " as a proxy: " + err.Error())
-			return nil, err
+			return nil, fmt.Errorf("failed to parse  " + proxyUrl + " as a proxy: " + err.Error())
 		}
 	}
 


### PR DESCRIPTION
`go vet` reports the following issues:

```
raidman.go:94: result of fmt.Errorf call not used
raidman.go:97: result of fmt.Errorf call not used
```

This patch fixes this under the assumption that you wanted to return the generated errors. Could you double check and/or fix, please?