### PR TITLE
Propagate errors of net.Conn's Close method

### DIFF
--- a/raidman.go
+++ b/raidman.go
@@ -334,8 +334,8 @@ func (c *Client) Query(q string) ([]Event, error) {
 }
 
 // Close closes the connection to Riemann
-func (c *Client) Close() {
+func (c *Client) Close() error {
 	c.Lock()
-	c.connection.Close()
-	c.Unlock()
+	defer c.Unlock()
+	return c.connection.Close()
 }


### PR DESCRIPTION
Hiding the error which `net.Conn` returns on `Close` prevents the end user for acting in some special cases.

This PR adds commit which just propagates the error  returned by `net.Conn.Close` to the caller of `Client.Close`.